### PR TITLE
fix phenomic blog

### DIFF
--- a/posts/ssh-host-config.md
+++ b/posts/ssh-host-config.md
@@ -3,7 +3,7 @@ title: ssh `Host` configuration
 layout: Post
 tagline: Configure ssh for multiple hosts
 tags: git, ssh
---------------
+---
 
 If you have found yourself committing to multiple git remotes, connecting to multiple remote servers with ssh, you may find typing all the necessary arguments tedious. In this post I will show how you can use ssh configuration to make these tasks fair less painful. After this you will be able to do the following:
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,19 +1,20 @@
-FROM nodesource/jessie:4.4.7
+FROM node:6.9.1
 
 RUN apt-get update
 RUN apt-get install git
 
-RUN useradd -ms /bin/bash blogbuilder
+RUN useradd --user-group --create-home --shell /bin/false blogbuilder &&\
+  npm install --global npm@4.0.3 &&\
+  npm install --global yarn@0.17.10
+
+
 USER blogbuilder
 WORKDIR /home/blogbuilder
-
-RUN npm i npm -g
-RUN npm i yarn -g
 
 RUN git clone https://github.com/impaler/cd-blog-phenomic.git cd-blog-phenomic
 
 WORKDIR /home/blogbuilder/cd-blog-phenomic
-RUN npm --production=false install
+RUN npm install
 
 EXPOSE 3000
 CMD "ip add | grep global"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,21 +1,26 @@
 FROM node:6.9.1
 
+# Setup env dependencies
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update
-RUN apt-get install git
+RUN apt-get install git yarn -y
 
-RUN useradd --user-group --create-home --shell /bin/false blogbuilder &&\
-  npm install --global yarn@0.17.10
+# Use the base image guid 1000 user node for building for easier
+# Permissions in development
+USER node
 
-
-USER blogbuilder
-WORKDIR /home/blogbuilder
-
+# Setup the phenomic static blog project
+WORKDIR /home/node
 RUN git clone https://github.com/impaler/cd-blog-phenomic.git cd-blog-phenomic
+WORKDIR /home/node/cd-blog-phenomic
+RUN git checkout develop
 
-WORKDIR /home/blogbuilder/cd-blog-phenomic
+# Add host content and for the build
+#ADD posts /home/node/cd-blog-phenomic/content/posts
+#ADD assets /home/node/cd-blog-phenomic/content/assets
 
 RUN yarn install
 
+# allow the phenomic watch port for development
 EXPOSE 3000
-CMD "ip add | grep global"
-ENTRYPOINT ["/usr/local/bin/yarn", "run"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -7,6 +7,9 @@ RUN useradd -ms /bin/bash blogbuilder
 USER blogbuilder
 WORKDIR /home/blogbuilder
 
+RUN npm i npm -g
+RUN npm i yarn -g
+
 RUN git clone https://github.com/impaler/cd-blog-phenomic.git cd-blog-phenomic
 
 WORKDIR /home/blogbuilder/cd-blog-phenomic

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -17,4 +17,4 @@ RUN yarn install
 
 EXPOSE 3000
 CMD "ip add | grep global"
-ENTRYPOINT ["/usr/bin/npm", "run-script"]
+ENTRYPOINT ["/usr/bin/yarn", "run"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -13,11 +13,9 @@ WORKDIR /home/blogbuilder
 RUN git clone https://github.com/impaler/cd-blog-phenomic.git cd-blog-phenomic
 
 WORKDIR /home/blogbuilder/cd-blog-phenomic
-RUN yarn install
 
-RUN whereis yarn
-RUN ls -lah
+RUN yarn install
 
 EXPOSE 3000
 CMD "ip add | grep global"
-ENTRYPOINT ["/usr/bin/yarn", "run"]
+ENTRYPOINT ["/usr/local/bin/yarn", "run"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -15,6 +15,9 @@ RUN git clone https://github.com/impaler/cd-blog-phenomic.git cd-blog-phenomic
 WORKDIR /home/blogbuilder/cd-blog-phenomic
 RUN yarn install
 
+RUN whereis yarn
+RUN ls -lah
+
 EXPOSE 3000
 CMD "ip add | grep global"
 ENTRYPOINT ["/usr/bin/yarn", "run"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update
 RUN apt-get install git
 
 RUN useradd --user-group --create-home --shell /bin/false blogbuilder &&\
-  npm install --global npm@4.0.3 &&\
   npm install --global yarn@0.17.10
 
 
@@ -14,7 +13,7 @@ WORKDIR /home/blogbuilder
 RUN git clone https://github.com/impaler/cd-blog-phenomic.git cd-blog-phenomic
 
 WORKDIR /home/blogbuilder/cd-blog-phenomic
-RUN npm install
+RUN yarn install
 
 EXPOSE 3000
 CMD "ip add | grep global"

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -4,11 +4,11 @@ const parentStdio = {stdio:[0,1,2]}
 
 const CD_BLOG_NAME = 'christopherdecoster.com'
 const HOST_BUILD_DIR = path.resolve(__dirname, '..')
-const CONTAINER_BUILD_DIR = '/home/blogbuilder/cd-blog-phenomic'
+const CONTAINER_BUILD_DIR = '/home/node/cd-blog-phenomic'
 const MOUNT_CONTENT_ARGS = `-v ${HOST_BUILD_DIR}/assets:${CONTAINER_BUILD_DIR}/content/assets -v ${HOST_BUILD_DIR}/posts:${CONTAINER_BUILD_DIR}/content/posts`
 
-if (process.argv.indexOf('start') > -1)
-    start()
+if (process.argv.indexOf('watch') > -1)
+    watch()
 else if (process.argv.indexOf('build') > -1)
     build()
 else if (process.argv.indexOf('buildImage') > -1)
@@ -17,32 +17,39 @@ else if (process.argv.indexOf('buildImage') > -1)
 else {
     console.error(`
 Unknown run argument, you can use:
-    node/scripts/run.js buildImage // build the docker image
+    node/scripts/run.js buildImage // build the docker image, use CLEAR_CACHE to invalidate docker cache
     node/scripts/run.js build // build production site to dist folder
-    node/scripts/run.js start // run the watch task for writing blog posts
+    node/scripts/run.js watch // run the watch task for writing blog posts
 `)
     process.exit(1)
 }
 
-function start() {
-    execSync(`docker run -ti ${MOUNT_CONTENT_ARGS} --rm ${CD_BLOG_NAME} start`, parentStdio)
+function watch() {
+    execSync(`docker run -ti ${MOUNT_CONTENT_ARGS} --rm ${CD_BLOG_NAME} yarn start`, parentStdio)
 }
 
 function build() {
     execSync(`rm -rf ${HOST_BUILD_DIR}/dist`, parentStdio)
     execSync(`mkdir ${HOST_BUILD_DIR}/dist`, parentStdio)
 
-    execSync(`docker run --user $(id -u $USER) ${MOUNT_CONTENT_ARGS} -v ${HOST_BUILD_DIR}/dist:${CONTAINER_BUILD_DIR}/dist ${CD_BLOG_NAME} build`, parentStdio)
+    const buildCommand = 'yarn build'
+
+    execSync(`docker run --user $(id -u) ${MOUNT_CONTENT_ARGS} -v ${HOST_BUILD_DIR}/dist:${CONTAINER_BUILD_DIR}/dist ${CD_BLOG_NAME} ${buildCommand}`, parentStdio)
 }
 
 function buildImage() {
+    // allow the clearing of cache by env setting
+    const cache = !!process.env.CLEAR_CACHE ? '--no-cache' : ''
+
+    // replace any existing build, content is separated so no big deal about env
     tryToRemoveImage(CD_BLOG_NAME)
-    execSync(`docker build -t ${CD_BLOG_NAME} .`, Object.assign({cwd:__dirname}, parentStdio) )
+
+    execSync(`docker build -t ${CD_BLOG_NAME} . ${cache}`, Object.assign({cwd:__dirname}, parentStdio) )
 }
 
 function tryToRemoveImage(imageName) {
     try {
-        var rmReturn = execSync(`docker rm -f ${imageName}`)
+        execSync(`docker rm -f ${imageName}`)
     } catch(error) {
         // swallow error for:
         // Error response from daemon: No such container: ...


### PR DESCRIPTION
Phenomic upstream dependencies broke the build.

Rethink some of the build script and move to yarn with a lock file so this doesn't happen again.

- Minor refactor to run script, run => watch.
- Added process ENV feature to buildImage CLEAR_CACHE for a docker rebuilds.
- Added some comments in dockerfile